### PR TITLE
Fixes #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ $ npm test
 NOTE: Be sure to keep up to date the plugin tests and jshint code quality.
 
 ## Release History
+  * 2014-03-30   v1.2.1   Bugfix. Fixes [issue 29](https://github.com/heldr/grunt-smushit/issues/29).
   * 2014-03-03   v1.2.0   Use cwd only for source files, following the [grunt pattern][grunt-cwd-pattern]
   * 2013-07-15   v1.1.0   Support nested folder structure, support for multiple source folders
   * 2013-07-15   v1.1.0   Enable the use of cwd parameter

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-smushit",
   "description": "Grunt plugin to remove unnecessary bytes of PNG and JPG using Yahoo Smushit",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": "https://github.com/heldr/grunt-smushit",
   "author": {
     "name": "Helder Santana",

--- a/tasks/smushit.js
+++ b/tasks/smushit.js
@@ -15,7 +15,7 @@ module.exports = function (grunt) {
 
   function getSubPath(fileDir, filepath) {
     fileDir = path.normalize(fileDir.replace(/\/(\*\*\/|\*)[\w\W]*[\/]?$/, "") + '/');      // regex: remove **/... or *... if it's a dir needed to be expanded
-    return filepath.substring(fileDir.length);
+    return path.normalize(filepath).substring(fileDir.length);
   }
 
   grunt.registerMultiTask('smushit', 'A Grunt task to remove unnecessary bytes of PNG and JPG using Yahoo Smushit.', function () {


### PR DESCRIPTION
- Update getSubPath function in /tasks/smushit.js to normalize
  filepath parameter similar to how the fileDir parameter is
  normalized. This fixes #29, in which src patterns such as ./img
  create an extraneous g/ directory in the dest directory.
- Update version in package.json to v1.2.1.
- Update release history in README with v.1.2.1 deets.
