### PR TITLE
Update API Endpoint

### DIFF
--- a/tasks/lib/runner.js
+++ b/tasks/lib/runner.js
@@ -6,7 +6,7 @@ module.exports = function (target, done) {
             onComplete: function (response) {
                 done(true);
             },
-            service: 'http://www.resmush.it/ws.php'
+            service: 'http://api.resmush.it/ws.php'
         });
 
     if (!smushit_settings.recursive) {


### PR DESCRIPTION
For better performances, reSmush.it API endpoint has changed. Since March 2016, it must call api.resmush.it/ws.php instead of www.resmush.it/ws.php